### PR TITLE
Fix unifi controller task being changed on restart

### DIFF
--- a/ansible/roles/unifi/handlers/main.yml
+++ b/ansible/roles/unifi/handlers/main.yml
@@ -1,2 +1,4 @@
+---
+
 - name: Restart unifi controller
-  command: docker restart unifi-app
+  ansible.builtin.command: docker restart unifi-app

--- a/ansible/roles/unifi/handlers/main.yml
+++ b/ansible/roles/unifi/handlers/main.yml
@@ -1,0 +1,2 @@
+- name: Restart unifi controller
+  command: docker restart unifi-app

--- a/ansible/roles/unifi/tasks/main.yml
+++ b/ansible/roles/unifi/tasks/main.yml
@@ -6,14 +6,6 @@
     state: directory
     mode: 0775
 
-- name: Change web admin port
-  ansible.builtin.lineinfile:
-    path: "{{ unifi_dir }}/data/system.properties"
-    regexp: "^unifi.https.port="
-    line: "unifi.https.port={{ unifi_web_admin_port }}"
-    create: true
-    mode: 0775
-
 - name: Create Unifi controller app container
   community.general.docker_container:
     name: unifi-app
@@ -43,3 +35,12 @@
       traefik.http.routers.unifi.tls: "true"
       traefik.http.services.unifi.loadbalancer.server.scheme: "https"
       traefik.http.services.unifi.loadbalancer.server.port: "{{ unifi_web_admin_port }}"
+
+- name: Change web admin port
+  ansible.builtin.lineinfile:
+    path: "{{ unifi_dir }}/data/system.properties"
+    regexp: "^unifi.https.port="
+    line: "unifi.https.port={{ unifi_web_admin_port }}"
+    create: true
+    mode: 0644
+  notify: Restart unifi controller


### PR DESCRIPTION
Ansible playbook was saying config file was being changed more often than I was expecting.

Controller application was changing config file to have 0644 permissions and lineinfile task was setting it to 0755.
Also add handler to restart the app after a config change